### PR TITLE
Changed Makefiles to use LDLIBS for libraries instead of LDFLAGS, fix…

### DIFF
--- a/01_basic-client-server/Makefile
+++ b/01_basic-client-server/Makefile
@@ -1,7 +1,7 @@
 .PHONY: clean
 
 CFLAGS  := -Wall -g
-LDFLAGS := ${LDFLAGS} -lrdmacm -libverbs -lpthread
+LDLIBS  := ${LDLIBS} -lrdmacm -libverbs -lpthread
 
 APPS    := server client
 

--- a/02_read-write/Makefile
+++ b/02_read-write/Makefile
@@ -2,17 +2,17 @@
 
 CFLAGS  := -Wall -Werror -g
 LD      := gcc
-LDFLAGS := ${LDFLAGS} -lrdmacm -libverbs -lpthread
+LDLIBS  := ${LDLIBS} -lrdmacm -libverbs -lpthread
 
 APPS    := rdma-client rdma-server
 
 all: ${APPS}
 
 rdma-client: rdma-common.o rdma-client.o
-	${LD} -o $@ $^ ${LDFLAGS}
+	${LD} -o $@ $^ ${LDLIBS}
 
 rdma-server: rdma-common.o rdma-server.o
-	${LD} -o $@ $^ ${LDFLAGS}
+	${LD} -o $@ $^ ${LDLIBS}
 
 clean:
 	rm -f *.o ${APPS}

--- a/03_file-transfer/rdma-file-transfer/Makefile
+++ b/03_file-transfer/rdma-file-transfer/Makefile
@@ -2,17 +2,17 @@
 
 CFLAGS  := -Wall -Werror -g
 LD      := gcc
-LDFLAGS := ${LDFLAGS} -lrdmacm -libverbs -lpthread
+LDLIBS  := ${LDLIBS} -lrdmacm -libverbs -lpthread
 
 APPS    := client server
 
 all: ${APPS}
 
 client: common.o client.o
-	${LD} -o $@ $^ ${LDFLAGS}
+	${LD} -o $@ $^ ${LDLIBS}
 
 server: common.o server.o
-	${LD} -o $@ $^ ${LDFLAGS}
+	${LD} -o $@ $^ ${LDLIBS}
 
 clean:
 	rm -f *.o ${APPS}


### PR DESCRIPTION
…ing compilation issues

I was unable to compile using the provided Makefile, as specifying libraries in LDFLAGS results in a wrong order. See also: http://ao2.it/en/blog/2011/11/27/dont-mix-ldflags-and-ldlibs