### PR TITLE
remove unnecessary access flags in ibv_reg_mr()

### DIFF
--- a/01_basic-client-server/client.c
+++ b/01_basic-client-server/client.c
@@ -167,13 +167,13 @@ void register_memory(struct connection *conn)
     s_ctx->pd, 
     conn->send_region, 
     BUFFER_SIZE, 
-    IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE));
+    0));
 
   TEST_Z(conn->recv_mr = ibv_reg_mr(
     s_ctx->pd, 
     conn->recv_region, 
     BUFFER_SIZE, 
-    IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE));
+    IBV_ACCESS_LOCAL_WRITE));
 }
 
 int on_addr_resolved(struct rdma_cm_id *id)

--- a/01_basic-client-server/server.c
+++ b/01_basic-client-server/server.c
@@ -172,13 +172,13 @@ void register_memory(struct connection *conn)
     s_ctx->pd,
     conn->send_region,
     BUFFER_SIZE,
-    IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE));
+    0));
 
   TEST_Z(conn->recv_mr = ibv_reg_mr(
     s_ctx->pd,
     conn->recv_region,
     BUFFER_SIZE,
-    IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE));
+    IBV_ACCESS_LOCAL_WRITE));
 }
 
 void on_completion(struct ibv_wc *wc)

--- a/02_read-write/rdma-common.c
+++ b/02_read-write/rdma-common.c
@@ -285,25 +285,25 @@ void register_memory(struct connection *conn)
     s_ctx->pd, 
     conn->send_msg, 
     sizeof(struct message), 
-    IBV_ACCESS_LOCAL_WRITE));
+    0));
 
   TEST_Z(conn->recv_mr = ibv_reg_mr(
     s_ctx->pd, 
     conn->recv_msg, 
     sizeof(struct message), 
-    IBV_ACCESS_LOCAL_WRITE | ((s_mode == M_WRITE) ? IBV_ACCESS_REMOTE_WRITE : IBV_ACCESS_REMOTE_READ)));
+    IBV_ACCESS_LOCAL_WRITE));
 
   TEST_Z(conn->rdma_local_mr = ibv_reg_mr(
     s_ctx->pd, 
     conn->rdma_local_region, 
     RDMA_BUFFER_SIZE, 
-    IBV_ACCESS_LOCAL_WRITE));
+    ((s_mode == M_WRITE) ? 0 : IBV_ACCESS_LOCAL_WRITE));
 
   TEST_Z(conn->rdma_remote_mr = ibv_reg_mr(
     s_ctx->pd, 
     conn->rdma_remote_region, 
     RDMA_BUFFER_SIZE, 
-    IBV_ACCESS_LOCAL_WRITE | ((s_mode == M_WRITE) ? IBV_ACCESS_REMOTE_WRITE : IBV_ACCESS_REMOTE_READ)));
+    ((s_mode == M_WRITE) ? (IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE) : IBV_ACCESS_REMOTE_READ)));
 }
 
 void send_message(struct connection *conn)

--- a/03_file-transfer/rdma-file-transfer/client.c
+++ b/03_file-transfer/rdma-file-transfer/client.c
@@ -95,10 +95,10 @@ static void on_pre_conn(struct rdma_cm_id *id)
   struct client_context *ctx = (struct client_context *)id->context;
 
   posix_memalign((void **)&ctx->buffer, sysconf(_SC_PAGESIZE), BUFFER_SIZE);
-  TEST_Z(ctx->buffer_mr = ibv_reg_mr(rc_get_pd(), ctx->buffer, BUFFER_SIZE, IBV_ACCESS_LOCAL_WRITE));
+  TEST_Z(ctx->buffer_mr = ibv_reg_mr(rc_get_pd(), ctx->buffer, BUFFER_SIZE, 0));
 
   posix_memalign((void **)&ctx->msg, sysconf(_SC_PAGESIZE), sizeof(*ctx->msg));
-  TEST_Z(ctx->msg_mr = ibv_reg_mr(rc_get_pd(), ctx->msg, sizeof(*ctx->msg), IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE));
+  TEST_Z(ctx->msg_mr = ibv_reg_mr(rc_get_pd(), ctx->msg, sizeof(*ctx->msg), IBV_ACCESS_LOCAL_WRITE));
 
   post_receive(id);
 }

--- a/03_file-transfer/rdma-file-transfer/server.c
+++ b/03_file-transfer/rdma-file-transfer/server.c
@@ -65,7 +65,7 @@ static void on_pre_conn(struct rdma_cm_id *id)
   TEST_Z(ctx->buffer_mr = ibv_reg_mr(rc_get_pd(), ctx->buffer, BUFFER_SIZE, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE));
 
   posix_memalign((void **)&ctx->msg, sysconf(_SC_PAGESIZE), sizeof(*ctx->msg));
-  TEST_Z(ctx->msg_mr = ibv_reg_mr(rc_get_pd(), ctx->msg, sizeof(*ctx->msg), IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE));
+  TEST_Z(ctx->msg_mr = ibv_reg_mr(rc_get_pd(), ctx->msg, sizeof(*ctx->msg), 0));
 
   post_receive(id);
 }


### PR DESCRIPTION
Since local read access is always enabled for each MR, additional access flags is not needed for MRs used in SEND only;
For MRs used in RECV, only IBV_ACCESS_LOCAL_WRITE is required;
I have compiled && tested these changes.