### PR TITLE
fix compiled error (lack a right parentheses)

### DIFF
--- a/02_read-write/rdma-common.c
+++ b/02_read-write/rdma-common.c
@@ -297,7 +297,7 @@ void register_memory(struct connection *conn)
     s_ctx->pd, 
     conn->rdma_local_region, 
     RDMA_BUFFER_SIZE, 
-    ((s_mode == M_WRITE) ? 0 : IBV_ACCESS_LOCAL_WRITE));
+    ((s_mode == M_WRITE) ? 0 : IBV_ACCESS_LOCAL_WRITE)));
 
   TEST_Z(conn->rdma_remote_mr = ibv_reg_mr(
     s_ctx->pd, 


### PR DESCRIPTION
original:
# make
cc -Wall -Werror -g   -c -o rdma-common.o rdma-common.c
rdma-common.c: In function ‘register_memory’:
rdma-common.c:344:0: error: unterminated argument list invoking macro "TEST_Z"
 }
 
rdma-common.c:296:3: error: ‘TEST_Z’ undeclared (first use in this function)
   TEST_Z(conn->rdma_local_mr = ibv_reg_mr(
   ^~~~~~
rdma-common.c:296:3: note: each undeclared identifier is reported only once for each function it appears in
rdma-common.c:296:3: error: expected ‘;’ at end of input
rdma-common.c:296:3: error: expected declaration or statement at end of input
rdma-common.c: At top level:
rdma-common.c:65:13: error: ‘send_message’ used but never defined [-Werror]
 static void send_message(struct connection *conn);
             ^~~~~~~~~~~~
cc1: all warnings being treated as errors
<builtin>: recipe for target 'rdma-common.o' failed
make: *** [rdma-common.o] Error 1



After searching the code, I found the reason was lacking a right parentheses.